### PR TITLE
refactor data to use markdown

### DIFF
--- a/astro-frontend/package-lock.json
+++ b/astro-frontend/package-lock.json
@@ -14,6 +14,7 @@
         "tailwindcss": "^3.3.3"
       },
       "devDependencies": {
+        "@tailwindcss/typography": "^0.5.10",
         "@typescript-eslint/eslint-plugin": "^6.8.0",
         "@typescript-eslint/parser": "^6.8.0",
         "cypress": "^13.3.1",
@@ -1105,6 +1106,34 @@
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
       "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
       "dev": true
+    },
+    "node_modules/@tailwindcss/typography": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.10.tgz",
+      "integrity": "sha512-Pe8BuPJQJd3FfRnm6H0ulKIGoMEQS+Vq01R6M5aCrFB/ccR/shT+0kXLjouGC1gFLm9hopTFN+DMP0pfwRWzPw==",
+      "dev": true,
+      "dependencies": {
+        "lodash.castarray": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.merge": "^4.6.2",
+        "postcss-selector-parser": "6.0.10"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || insiders"
+      }
+    },
+    "node_modules/@tailwindcss/typography/node_modules/postcss-selector-parser": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "dev": true,
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.2",
@@ -5520,6 +5549,18 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
+    },
+    "node_modules/lodash.castarray": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.castarray/-/lodash.castarray-4.4.0.tgz",
+      "integrity": "sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q==",
+      "dev": true
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
       "dev": true
     },
     "node_modules/lodash.merge": {

--- a/astro-frontend/package.json
+++ b/astro-frontend/package.json
@@ -19,6 +19,7 @@
     "tailwindcss": "^3.3.3"
   },
   "devDependencies": {
+    "@tailwindcss/typography": "^0.5.10",
     "@typescript-eslint/eslint-plugin": "^6.8.0",
     "@typescript-eslint/parser": "^6.8.0",
     "cypress": "^13.3.1",

--- a/astro-frontend/src/components/NewsItem.astro
+++ b/astro-frontend/src/components/NewsItem.astro
@@ -1,0 +1,20 @@
+---
+const { item } = Astro.props;
+const { Content } = await item.render();
+---
+
+<div class="py-4 space-y-2 prose max-w-none">
+  <div class="space-x-2">
+    <span class="text-gray-500 text-sm">
+      <span>{item.data.program}</span> | <span>{item.data.date}</span>
+    </span>
+    <span
+      class={`${
+        item.data.tag === "NEW" ? "bg-green-700" : "bg-orange-700"
+      } text-white px-2 py-0.5 font-semibold text-xs inline-block`}
+    >
+      {item.data.tag}
+    </span>
+  </div>
+  <Content />
+</div>

--- a/astro-frontend/src/content/news/en/item1.md
+++ b/astro-frontend/src/content/news/en/item1.md
@@ -1,0 +1,10 @@
+---
+program: "OLD AGE SECURITY"
+date: "2023-05-21"
+tag: "UPDATED"
+"draft": false
+---
+
+## Increase in Old Age Security (OAS) for Those 75 and Older
+
+Starting July 2022, Old Age Security (OAS) pensions will automatically increase by 10% for those who are or will be 75 by June 2022. If your 75th birthday is after July 1, 2022, you'll receive this increase in the month right after you turn 75. Importantly, this 10% increase won't won't affect your Guaranteed Income Supplement (GIS).

--- a/astro-frontend/src/content/news/en/item2.md
+++ b/astro-frontend/src/content/news/en/item2.md
@@ -1,0 +1,10 @@
+---
+program: "SERVICE DISRUPTIONS"
+date: "2023-08-18"
+tag: "NEW"
+"draft": false
+---
+
+## Temporary Closure Alert: Regina North Central Scheduled Outreach Site
+
+Our Regina North Central Scheduled Outreach Site (Regina) is temporarily closed. We apologize for any inconvenience and will keep you updated on when services will resume. For immediate assistance, please use our online services -(can we link?)  or request a callback. (can we link?)

--- a/astro-frontend/src/content/news/en/item3.md
+++ b/astro-frontend/src/content/news/en/item3.md
@@ -1,0 +1,10 @@
+---
+program: "CANADA DENTAL BENEFIT"
+date: "2023-06-22"
+tag: "NEW"
+"draft": false
+---
+
+## Dental Benefit Applications Now Open for 2023-2024
+
+Applications for the Dental Benefit are now open for the period spanning July 1, 2023, to June 30, 2024. Log into your CRA My Account and follow the prompts to apply.

--- a/astro-frontend/src/content/news/en/item4.md
+++ b/astro-frontend/src/content/news/en/item4.md
@@ -1,0 +1,19 @@
+---
+program: "SERVICE DISRUPTIONS"
+date: "2023-08-16"
+tag: "NEW"
+"draft": false
+---
+
+## Important Update: Sign-In Partner Caisse Alliance Temporarily Unavailable
+
+Starting October 16, 2023, Caisse Alliance is no longer be used a Sign-In Partner to access:
+
+- My Service Canada Account (MSCA)
+- Canada Revenue Agency - My Account
+- Canada Revenue Agency - My Business Account
+- National Student Loans Service Centre account
+- ROE Web
+- Grants and Contributions Online Services (GCOS)
+
+We expect that Caisse Alliance will be back as a Sign-In Partner in early 2024. Meanwhile, you can use an alternative Sign-In Partner or another sign-in method for your transactions.

--- a/astro-frontend/src/content/news/en/item5.md
+++ b/astro-frontend/src/content/news/en/item5.md
@@ -1,0 +1,10 @@
+---
+program: "GUARANTEED INCOME SUPPLEMENT"
+date: "2023-07-05"
+tag: "UPDATED"
+"draft": false
+---
+
+## New one-time grant for Allowance and Guaranteed Income Supplement (GIS) Benefits recipients
+
+You could receive a special one-time taxable payment if your Allowance or GIS amount was reduced after receiving  the CERB or CRB (Canada Emergency Response Benefit or Canada Recovery Benefit). This payment equals the amount of benefits you lost starting from July 2021.

--- a/astro-frontend/src/content/news/en/item6.md
+++ b/astro-frontend/src/content/news/en/item6.md
@@ -1,0 +1,10 @@
+---
+program: "GROCERY REBATE"
+date: "2023-06-15"
+tag: "NEW"
+"draft": false
+---
+
+## Date for the Grocery Rebate
+
+On July 5, 2023, the Grocery Rebate payment will be issued alongside the GST/HST credit. No need to apply—just make sure you've filed your 2021 tax return. The amount you receive is based on your family situation as of January 2023 and your 2021 income. You could get the Grocery Rebate even if you're not eligible for the July GST/HST. Consult this page to learn more.

--- a/astro-frontend/src/content/news/en/item7.md
+++ b/astro-frontend/src/content/news/en/item7.md
@@ -1,0 +1,10 @@
+---
+program: "OLD AGE SECURITY"
+date: "2023-09-15"
+tag: "UPDATED"
+"draft": false
+---
+
+## New OAS Rates Coming in October 2023
+
+Starting in October 2023, your basic Old Age Security (OAS) pension will increase. The monthly payment will increase to $707.68—an uplift of 1.3%. For Seniors 75 and Over: Your basic OAS pension will increase to $778.45 per month.

--- a/astro-frontend/src/content/news/en/item8.md
+++ b/astro-frontend/src/content/news/en/item8.md
@@ -1,0 +1,10 @@
+---
+program: "EMPLOYMENT INSURANCE"
+date: "2023-10-15"
+tag: "UPDATED"
+"draft": false
+---
+
+## Increase of maximum number of weeks of EI Sickness Benefits to 26 Weeks
+
+Effective for claims with a start date on or after December 18, 2022, the maximum weeks of benefits you can receive is now extended from 15 to 26 weeks. This extension also applies to Special benefits for self-employed individuals. Note: For claims initiated before December 18, 2022, the maximum entitlement remains at 15 weeks.

--- a/astro-frontend/src/content/news/fr/item1.md
+++ b/astro-frontend/src/content/news/fr/item1.md
@@ -1,0 +1,10 @@
+---
+program: "OLD AGE SECURITY"
+date: "2023-05-21"
+tag: "UPDATED"
+"draft": false
+---
+
+## Augmentation de la Sécurité de la vieillesse (SV) pour les personnes âgées de 75 ans et plus
+
+À partir de juillet 2022, les pensions de la Sécurité de la vieillesse (SV) augmenteront automatiquement de 10 % pour ceux qui ont ou auront 75 ans d'ici juin 2022. Si votre 75e anniversaire est après le 1er juillet 2022, vous recevrez cette augmentation le mois suivant votre 75e anniversaire. Il est important de noter que cette augmentation de 10 % n'affectera pas votre Supplément de revenu garanti (SRG).

--- a/astro-frontend/src/content/news/fr/item2.md
+++ b/astro-frontend/src/content/news/fr/item2.md
@@ -1,0 +1,10 @@
+---
+program: "SERVICE DISRUPTIONS"
+date: "2023-08-18"
+tag: "NEW"
+"draft": false
+---
+
+## Alerte de fermeture temporaire : site de portée planifiée du Centre-Nord de Regina
+
+Notre site de portée planifiée du Centre-Nord de Regina (Regina) est temporairement fermé. Nous nous excusons pour tout inconvénient et vous tiendrons informés de la reprise des services. Pour une assistance immédiate, veuillez utiliser nos services en ligne (can we link?) ou demander un rappel (can we link?)

--- a/astro-frontend/src/content/news/fr/item3.md
+++ b/astro-frontend/src/content/news/fr/item3.md
@@ -1,0 +1,10 @@
+---
+program: "CANADA DENTAL BENEFIT"
+date: "2023-06-22"
+tag: "NEW"
+"draft": false
+---
+
+## Les demandes pour l'Avantage Dentaire sont maintenant ouvertes pour la période 2023-2024
+
+Les demandes pour l'Avantage Dentaire sont désormais ouvertes pour la période allant du 1er juillet 2023 au 30 juin 2024. Connectez-vous à votre compte de l'ARC et suivez les instructions pour faire votre demande.

--- a/astro-frontend/src/content/news/fr/item4.md
+++ b/astro-frontend/src/content/news/fr/item4.md
@@ -1,0 +1,18 @@
+---
+program: "SERVICE DISRUPTIONS"
+date: "2023-08-16"
+tag: "NEW"
+"draft": false
+---
+
+## Mise à jour importante : Le partenaire de connexion Caisse Alliance temporairement indisponible 
+
+À partir du 16 octobre 2023, Caisse Alliance ne peut plus être utilisé comme partenaire de connexion pour accéder aux services suivants :
+
+- Mon Dossier Service Canada (MDSC)
+- Agence du revenu du Canada - Mon dossier
+- Agence du revenu du Canada - Mon dossier d'entreprise
+- compte du Centre de service national de prêts aux étudiants
+- RE Web \n - Services en ligne des subventions et contributions (SELSC)
+
+Nous prévoyons que Caisse Alliance reviendra en tant que partenaire de connexion au début de 2024. En attendant, vous pouvez utiliser un autre partenaire de connexion ou une autre méthode de connexion pour vos transactions.

--- a/astro-frontend/src/content/news/fr/item5.md
+++ b/astro-frontend/src/content/news/fr/item5.md
@@ -1,0 +1,10 @@
+---
+program: "GUARANTEED INCOME SUPPLEMENT"
+date: "2023-07-05"
+tag: "UPDATED"
+"draft": false
+---
+
+## Nouvelle subvention unique pour les bénéficiaires de l'Allocation et du Supplément de revenu garanti (SRG)
+
+Vous pourriez recevoir un paiement spécial unique imposable si votre Allocation ou SRG a été réduit après avoir reçu la PCU ou la PCR (Prestation canadienne d'urgence ou Prestation canadienne de relance économique). Ce paiement équivaut au montant des prestations que vous avez perdues à partir de juillet 2021.

--- a/astro-frontend/src/content/news/fr/item6.md
+++ b/astro-frontend/src/content/news/fr/item6.md
@@ -1,0 +1,10 @@
+---
+program: "GROCERY REBATE"
+date: "2023-06-15"
+tag: "NEW"
+"draft": false
+---
+
+## Date pour le remboursement sur les produits alimentaires
+
+Le 5 juillet 2023, le paiement du remboursement sur les produits alimentaires sera émis en même temps que le crédit pour la TPS/TVH. Pas besoin de postuler — assurez-vous simplement d'avoir déposé votre déclaration de revenus de 2021. Le montant que vous recevrez est basé sur votre situation familiale en date de janvier 2023 et sur vos revenus de 2021. Vous pourriez obtenir le remboursement sur les produits alimentaires même si vous n'êtes pas admissible au crédit pour la TPS/TVH de juillet. Consultez cette page pour en savoir plus.

--- a/astro-frontend/src/content/news/fr/item7.md
+++ b/astro-frontend/src/content/news/fr/item7.md
@@ -1,0 +1,10 @@
+---
+program: "OLD AGE SECURITY"
+date: "2023-09-15"
+tag: "UPDATED"
+"draft": false
+---
+
+## New OAS Rates Coming in October 2023
+
+Starting in October 2023, your basic Old Age Security (OAS) pension will increase. The monthly payment will increase to $707.68—an uplift of 1.3%. For Seniors 75 and Over: Your basic OAS pension will increase to $778.45 per month.

--- a/astro-frontend/src/content/news/fr/item8.md
+++ b/astro-frontend/src/content/news/fr/item8.md
@@ -1,0 +1,10 @@
+---
+program: "EMPLOYMENT INSURANCE"
+date: "2023-10-15"
+tag: "UPDATED"
+"draft": false
+---
+
+## Augmentation du nombre maximal de semaines d'indemnités de maladie de l'AE à 26 semaines
+
+Pour les demandes initiées à partir du 18 décembre 2022, le nombre maximal de semaines d'indemnités que vous pouvez recevoir passe désormais de 15 à 26 semaines. Vous êtes travailleur autonome ? Vous êtes également couvert. Cette prolongation s'applique également aux prestations spéciales pour les travailleurs autonomes. Note : Pour les demandes initiées avant le 18 décembre 2022, le droit maximal reste fixé à 15 semaines.

--- a/astro-frontend/src/pages/[lang]/index.astro
+++ b/astro-frontend/src/pages/[lang]/index.astro
@@ -1,23 +1,24 @@
 ---
 import Layout from "../../layouts/Layout.astro";
 import { useTranslations } from "../../i18n/utils";
-import data from "../../data/news_items.json";
+import { getCollection } from "astro:content";
+import NewsItem from "../../components/NewsItem.astro";
 
 const { lang } = Astro.params;
 const t = useTranslations(lang);
-const programs = [...new Set(data.map((item) => item.program))];
 const searchParams = Object.fromEntries(Astro.url.searchParams);
+
+let newsItems = await getCollection("news", ({ id }) => id.startsWith(lang));
+newsItems.sort((a, b) => +new Date(b.data.date) - +new Date(a.data.date));
+const programs = [...new Set(newsItems.map((item) => item.data.program))];
 
 const filters = Object.fromEntries(Astro.url.searchParams);
 delete filters["page"];
 delete filters["search"];
 
-let filteredData = data.filter((item) => {
-  let haystack = `${lang === "en" ? item.en_title : item.fr_title} ${
-    lang === "en" ? item.en_body : item.fr_body
-  } ${item.program}`.toLocaleLowerCase();
-
-  let program = item.program.split(" ").join("_");
+let filteredData = newsItems.filter((item) => {
+  let haystack = `${item.body} ${item.data.program}`.toLocaleLowerCase();
+  let program = item.data.program.split(" ").join("_");
   let keys = Object.keys(filters);
 
   if (keys.length === 0 && "search" in searchParams) {
@@ -29,7 +30,7 @@ let filteredData = data.filter((item) => {
       haystack.includes(searchParams.search?.toLowerCase())
     );
   }
-  return !item.draft;
+  return !item.data.draft;
 });
 
 const page = +Astro.url.searchParams.get("page") ?? 0;
@@ -166,28 +167,7 @@ function createPaginatedUrl(pageNum: number) {
           </div>
 
           <div class="bg-white divide-y px-2 md:px-10 py-5 space-y-4">
-            {
-              filteredData.map((item) => (
-                <div class="py-4 space-y-2">
-                  <div class="space-x-2">
-                    <span class="text-gray-500 text-sm">
-                      <span>{item.program}</span> | <span>{item.date}</span>
-                    </span>
-                    <span
-                      class={`${
-                        item.tag === "NEW" ? "bg-green-700" : "bg-orange-700"
-                      } text-white px-2 py-0.5 font-semibold text-xs inline-block`}
-                    >
-                      {item.tag}
-                    </span>
-                  </div>
-                  <h2 class="text-2xl font-semibold">
-                    {lang === "en" ? item.en_title : item.fr_title}
-                  </h2>
-                  <p>{lang === "en" ? item.en_body : item.fr_body}</p>
-                </div>
-              ))
-            }
+            {filteredData.map((item) => <NewsItem item={item} />)}
           </div>
           <div class="text-right">
             {

--- a/astro-frontend/tailwind.config.mjs
+++ b/astro-frontend/tailwind.config.mjs
@@ -8,5 +8,5 @@ export default {
       },
     },
   },
-  plugins: [],
+  plugins: [require("@tailwindcss/typography")],
 };


### PR DESCRIPTION
Markdown is a more sensible design decision here because of the content of some of the news items.  Add tailwind typography to make it render pretty.  Refactored news items into their own component.